### PR TITLE
Performance update to InitializeCheckDocumentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "bdev-al-xml-doc",
-	"version": "0.4.0",
+	"version": "0.4.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -41,6 +41,15 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
 			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
 			"dev": true
+		},
+		"@types/fs-extra": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.1.tgz",
+			"integrity": "sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/glob": {
 			"version": "7.1.3",
@@ -236,6 +245,11 @@
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
+		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -752,6 +766,17 @@
 			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
 		},
+		"fs-extra": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+			"requires": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^1.0.0"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -814,6 +839,11 @@
 			"requires": {
 				"type-fest": "^0.8.1"
 			}
+		},
+		"graceful-fs": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -1130,6 +1160,15 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
+		},
+		"jsonfile": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+			"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^1.0.0"
+			}
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -1775,6 +1814,11 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
 			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
 			"dev": true
+		},
+		"universalify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
 		},
 		"uri-js": {
 			"version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
 	},
 	"dependencies": {
 		"fast-xml-parser": "^3.17.4",
+		"fs-extra": "^9.0.1",
 		"vscode-languageclient": "^6.1.3"
 	},
 	"scripts": {
@@ -159,6 +160,7 @@
 		"test": "node ./out/test/runTest.js"
 	},
 	"devDependencies": {
+		"@types/fs-extra": "^9.0.1",
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.13.14",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,14 +5,19 @@ import { DoHover } from "./DoHover";
 import { DoCheckDocumentation } from "./DoCheckDocumentation";
 import { Configuration } from "./util/Configuration";
 
-export function activate(context: ExtensionContext) {	
+export async function activate(context: ExtensionContext) {	
 	Configuration.AskEnableCheckProcedureDocumentation();
 
 	const doComment = new DoComment();
 	const doExport = new DoExport();
 	const doHover = new DoHover();
 	const doCheckDocumentation = new DoCheckDocumentation();
-
+	let startTime = Date.now();
+	doCheckDocumentation.InitializeCheckDocumentation().then(() => {
+		let endDate = Date.now();
+		console.log(`AL XML Documentation full-scan finished in ${endDate - startTime}ms`);
+	});
+	
 	context.subscriptions.push(doComment);
 	context.subscriptions.push(doExport);
 	context.subscriptions.push(doHover);

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,5 +22,6 @@ export enum ALXmlDocDiagnosticCode {
 	SummaryMissing = "DOC0002", // Summary is missing
 	ParameterMissing = "DOC0010", // Parameter documentation is missing
 	ParameterUnnecessary = "DOC0011", // Parameter documentation is unnecessary
-	ReturnTypeMissing = "DOC0020"  // Return Type documentation is missing
+	ReturnTypeMissing = "DOC0020",  // Return Type documentation is missing
+	RemarkMissing = "DOC0099" // ??? It was missing and gave compilation failure, temporarily set to 99
 }

--- a/src/util/ALCheckDocumentation.ts
+++ b/src/util/ALCheckDocumentation.ts
@@ -5,7 +5,7 @@ import { ALDocCommentUtil } from "./ALDocCommentUtil";
 import { ALXmlDocDiagnosticCode, ALXmlDocDiagnosticPrefix } from "../types";
 import { Configuration } from "./Configuration";
 
-export class ALCheckDocumentation { 
+export class ALCheckDocumentation {
     private document!: TextDocument;
     private diagnosticsCollection: DiagnosticCollection = languages.createDiagnosticCollection('al-xml-doc');
     private diagnostics: Diagnostic[] = [];
@@ -23,25 +23,25 @@ export class ALCheckDocumentation {
         }
 
         // retrieve all procedures in current document
-        let alProcedures = ALSyntaxUtil.FindProcedures(this.document.getText());
+        let alProcedures: Array<{ procedureName: string, lineNo: number }> = ALSyntaxUtil.FindProcedures(this.document.getText());
         if (!alProcedures) {
             return;
         }
 
         // check documentation
-        alProcedures.forEach((alProcedure: { procedureName : string, lineNo: number }) => {
+        for (let alProcedure of alProcedures) {
             this.UpdateMissingDocumentations(ALSyntaxUtil.GetALProcedureState(this.document, alProcedure.lineNo));
-        });        
+        };
         this.UpdateDiagnostics();
     }
 
-    private UpdateMissingDocumentations(alProcedureState: { name: string; position: Range; definition: { [key: string]: string; }; documentation: string } | null) {      
+    private UpdateMissingDocumentations(alProcedureState: { name: string; position: Range; definition: { [key: string]: string; }; documentation: string } | null) {
         if ((alProcedureState === null) || (alProcedureState === undefined)) {
             return;
         }
 
-        let diag: { 
-            type: DiagnosticSeverity, 
+        let diag: {
+            type: DiagnosticSeverity,
             diagnosticCode: ALXmlDocDiagnosticCode,
             element: string
         }[] = [];
@@ -141,7 +141,7 @@ export class ALCheckDocumentation {
                     switch (diag.diagnosticCode) {
                         case ALXmlDocDiagnosticCode.ParameterMissing:
                             diag.element = `parameter '${diag.element}'`;
-                        break;
+                            break;
                     }
                     msg = this.AppendString(msg, diag.element, ", ");
                     code = this.AppendString(code, this.GetDiagnosticCode(diag.diagnosticCode), ", ");
@@ -165,7 +165,7 @@ export class ALCheckDocumentation {
                 switch (diag.diagnosticCode) {
                     case ALXmlDocDiagnosticCode.ParameterUnnecessary:
                         diag.element = `parameter '${diag.element}'`;
-                    break;
+                        break;
                 }
                 msg = this.AppendString(msg, diag.element, ", ");
                 code = this.AppendString(code, diag.diagnosticCode, ", ");
@@ -188,17 +188,17 @@ export class ALCheckDocumentation {
 
     private IsMissingDocumentationDiag(element: { diagnosticCode: ALXmlDocDiagnosticCode; }, index: any, array: any) {
         return (
-            (element.diagnosticCode === ALXmlDocDiagnosticCode.XmlDocumentationMissing) || 
+            (element.diagnosticCode === ALXmlDocDiagnosticCode.XmlDocumentationMissing) ||
             (element.diagnosticCode === ALXmlDocDiagnosticCode.SummaryMissing) ||
-            (element.diagnosticCode === ALXmlDocDiagnosticCode.ParameterMissing) || 
-            (element.diagnosticCode === ALXmlDocDiagnosticCode.ReturnTypeMissing) || 
+            (element.diagnosticCode === ALXmlDocDiagnosticCode.ParameterMissing) ||
+            (element.diagnosticCode === ALXmlDocDiagnosticCode.ReturnTypeMissing) ||
             (element.diagnosticCode === ALXmlDocDiagnosticCode.RemarkMissing));
     }
 
     private IsUnnecessaryDocumentationDiag(element: { diagnosticCode: ALXmlDocDiagnosticCode; }, index: any, array: any) {
         return ((element.diagnosticCode === ALXmlDocDiagnosticCode.ParameterUnnecessary));
     }
-    
+
     private AppendString(baseString: string, append: string, concatString: string = ""): string {
         if (baseString.includes(append)) {
             return baseString;
@@ -219,7 +219,7 @@ export class ALCheckDocumentation {
         if (this.diagnostics === []) {
             this.diagnosticsCollection.clear();
         }
-        
+
         this.diagnosticsCollection.set(this.document.uri, this.diagnostics);
     }
 


### PR DESCRIPTION
Hi,

I have experienced notable negative effect on VSCode performance when your extension is activated and the workspace is pretty big, like a BaseApp or with at least 2-3000 AL files. Sometimes it resulted in preventing my extensions from activation.

The story goes back to Waldo's CRS extension that ultimately amplified the issue originated here in AL XML Doc:
https://github.com/waldo1001/crs-al-language-extension/pull/181

Well, it's not exactly an issue but more like performance considerations. Using VSCode api for mass file operations is unfortunately very inefficient as VSCode emits several events during opening a document.
Using `vscode.workspace.openTextDocument(filePath)` is equivalent to opening a file manually. So in case of 6000 files it's like opening each of them one-by-one where all the VSCode language analyzer stuff are also being activated each time.

I have examined the code and found the root cause in `doCheckDocumentation.InitializeCheckDocumentation`. I saw it can be turned off in settings, but I think we'd like to use a feature if possible. :)

I came up with several fixes:
1. Using nodejs FS api instead of VSCode's
2. After reading raw textcontent, we can filter out objects that have no procedures, thus avoiding further analysis
3. Usage of a TextDocument instance is not actually required by your code, so I substituted it with a small prototype.
3. Syntax analysis happens in batches asynchronously to ease CPU usage
4. Added a progress notification to the bottom statusbar, so users will know something is happening

After applying above changes, processing time went down from 5-6 minutes to 42 seconds for a BaseApp. And all this while AL Language itself also tried to come to terms with 6K files.

