### PR TITLE
Pass language parameter when writing examples for markdown

### DIFF
--- a/src/util/ALObjectDocumentationExport.ts
+++ b/src/util/ALObjectDocumentationExport.ts
@@ -317,7 +317,12 @@ pdf_options:
         if (documentation.example) {            
             doc.WriteHeading('Example', headingLevel);
             doc.WriteLine(documentation.example.value);
-            doc.WriteCode(documentation.example.code);
+            
+            if(documentation.example.lang) {
+                doc.WriteCode(documentation.example.code, documentation.example.lang);
+            } else{
+                doc.WriteCode(documentation.example.code);
+            }
         }
     }
 


### PR DESCRIPTION
To allow specifying examples in a different language the language parameter will now be passed to the WriteCode function when exporting examples to markdown.